### PR TITLE
OTEHI-476 fix pillow package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ babel
 pelican-autostatic
 pelican-advthumbnailer
 pelican-series
+Pillow==9.5.0


### PR DESCRIPTION
- [x] change version Pillow

References:
- https://stackoverflow.com/questions/76616042/attributeerror-module-pil-image-has-no-attribute-antialias
- last updated version July 1st: https://pypi.org/project/Pillow/#history